### PR TITLE
Revive Supabase

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,222 @@
+# Expo + React Native + TypeScript Project
+
+You are an expert in React Native, Expo, TypeScript, and mobile app development.
+
+## Key Principles
+
+- Write concise, technical TypeScript code with accurate examples
+- Use functional and declarative programming patterns; avoid classes
+- Prefer iteration and modularization over code duplication
+- Use descriptive variable names with auxiliary verbs (e.g., isLoading, hasError)
+- Structure files: imports, types, component, helpers, static content, exports
+
+## Tech Stack
+
+- React Native with Expo SDK 54+
+- Expo Router for file-based routing
+- TypeScript (strict mode)
+- NativeWind and StyleSheet for styling
+
+## React Native / Expo Best Practices
+
+### File-Based Routing with Expo Router
+
+- Use file-based routing in the `app/` directory
+- Dynamic routes: `[id].tsx`
+- Layout groups: `(tabs)/`, `(auth)/`
+- Layouts: `_layout.tsx`
+
+### Navigation
+
+```tsx
+import { router, Link, useLocalSearchParams } from 'expo-router';
+
+// Programmatic navigation
+router.push('/profile/123');
+router.replace('/login');
+
+// Declarative navigation
+<Link href="/profile/123">View Profile</Link>;
+
+// Access params
+const { id } = useLocalSearchParams();
+```
+
+### Components
+
+- Use functional components with TypeScript
+- Prefer named exports (except for Expo Router screens)
+- Use `View`, `Text`, `Pressable` from `react-native`
+- Import platform-specific code with `.ios.tsx` / `.android.tsx` extensions
+
+### File Naming
+
+- Components: kebab-case (e.g., `user-profile.tsx`)
+- Hooks: camelCase with 'use' prefix (e.g., `useAuth.ts`)
+- Utilities: camelCase (e.g., `formatDate.ts`)
+- Screens: Use Expo Router conventions (e.g., `[id].tsx`, `_layout.tsx`)
+
+### Styling
+
+```tsx
+// Using StyleSheet
+import { StyleSheet, View } from 'react-native';
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+});
+
+// Or using NativeWind (Tailwind)
+<View className="flex-1 p-4">
+```
+
+### State Management
+
+- Use `useState` for local state
+- Avoid prop drilling - use Context or Zustand
+
+### Performance
+
+- Use `FlashList` instead of `FlatList` for long lists
+- Memoize expensive calculations with `useMemo`
+- Memoize callbacks with `useCallback`
+- Use `React.memo` for pure components
+- Lazy load screens with `React.lazy` (when not using Expo Router)
+
+### Platform-Specific Code
+
+```tsx
+import { Platform } from 'react-native';
+
+// Inline platform check
+const padding = Platform.OS === 'ios' ? 20 : 10;
+
+// Platform.select
+const styles = StyleSheet.create({
+  container: {
+    ...Platform.select({
+      ios: { paddingTop: 20 },
+      android: { paddingTop: 10 },
+    }),
+  },
+});
+
+// Separate files
+// button.ios.tsx
+// button.android.tsx
+```
+
+## TypeScript Best Practices
+
+- Use strict mode
+- Avoid `any` - use `unknown` if type is truly unknown
+- Define interfaces for component props
+- Use type inference where possible
+- Use const assertions for constants
+
+```tsx
+// Good
+interface ButtonProps {
+  title: string;
+  onPress: () => void;
+  variant?: 'primary' | 'secondary';
+}
+
+export function Button({ title, onPress, variant = 'primary' }: ButtonProps) {
+  // Implementation
+}
+
+// Const assertion
+const colors = {
+  primary: '#007AFF',
+  secondary: '#5856D6',
+} as const;
+```
+
+## Expo Specific
+
+### Installing Dependencies
+
+**ALWAYS use `npx expo install` instead of npm/yarn:**
+
+```bash
+npx expo install react-native-reanimated
+npx expo install expo-image
+```
+
+This ensures SDK compatibility.
+
+### Environment Variables
+
+```bash
+# .env.local
+EXPO_PUBLIC_API_URL=https://api.example.com  # Available on client
+EXPO_PUBLIC_API_KEY=abc123                   # Available on client
+SECRET_KEY=secret123                          # Server-side only
+```
+
+```tsx
+// Usage
+const apiUrl = process.env.EXPO_PUBLIC_API_URL;
+```
+
+### Common Expo Modules
+
+- `expo-router` - File-based routing
+- `expo-image` - Optimized images
+- `expo-font` - Custom fonts
+- `expo-secure-store` - Secure storage
+- `expo-camera` - Camera access
+- `expo-location` - Location services
+- `expo-notifications` - Push notifications
+
+### API Routes
+
+```tsx
+// app/api/users+api.ts
+export async function GET(request: Request) {
+  const users = await db.users.findMany();
+  return Response.json(users);
+}
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const user = await db.users.create(body);
+  return Response.json(user, { status: 201 });
+}
+```
+
+## Error Handling
+
+```tsx
+try {
+  const result = await fetchData();
+} catch (error) {
+  if (error instanceof Error) {
+    console.error('Error:', error.message);
+  }
+  // Handle error appropriately
+}
+```
+
+## Important Reminders
+
+1. This is a mobile app - consider iOS and Android differences
+2. Always use `npx expo install` for dependencies
+3. Use Expo Router patterns, not React Navigation directly
+4. Consider performance on mobile devices
+5. Test on both iOS and Android
+6. Use TypeScript strictly - avoid `any`
+7. Follow React Native best practices (avoid web patterns that don't translate)
+
+## Code Generation Rules
+
+- When generating navigation code, use Expo Router APIs
+- When suggesting packages, verify Expo SDK compatibility
+- When creating layouts, remember mobile constraints (smaller screens)
+- When handling user input, consider mobile keyboards and gestures
+- When dealing with images, use `expo-image` over `Image`
+- When implementing forms, consider mobile UX (large touch targets, clear error states)

--- a/api/people/people-service.ts
+++ b/api/people/people-service.ts
@@ -41,10 +41,9 @@ export async function getPeople(
   userId: string,
 ): Promise<ServiceResponse<Person[]>> {
   const { data, error } = await supabase
-    .from('persons')
+    .from('v_persons')
     .select('*')
     .eq('user_id', userId)
-    .is('deleted_at', null)
     .order('created_at', { ascending: false });
 
   if (error) {
@@ -61,10 +60,9 @@ export async function getPerson(
   personId: string,
 ): Promise<ServiceResponse<Person>> {
   const { data, error } = await supabase
-    .from('persons')
+    .from('v_persons')
     .select('*')
     .eq('id', personId)
-    .is('deleted_at', null)
     .single();
 
   if (error) {
@@ -83,7 +81,7 @@ export async function updatePerson(
 ): Promise<ServiceResponse<Person>> {
   const { data, error } = await supabase
     .from('persons')
-    .update({ ...updates, updated_at: new Date().toISOString() })
+    .update(updates)
     .eq('id', personId)
     .select()
     .single();
@@ -126,10 +124,9 @@ export async function getPersonWithDetails(
 
   // First get the person
   const { data: person, error: personError } = await supabase
-    .from('persons')
+    .from('v_persons')
     .select('*')
     .eq('id', personId)
-    .is('deleted_at', null)
     .single();
 
   if (personError) {
@@ -145,10 +142,9 @@ export async function getPersonWithDetails(
 
   // Get facts ordered by newest first (created_at desc)
   const { data: facts, error: factsError } = await supabase
-    .from('facts')
+    .from('v_facts')
     .select('*')
     .eq('person_id', personId)
-    .is('deleted_at', null)
     .order('created_at', { ascending: false });
 
   if (factsError) {
@@ -157,10 +153,9 @@ export async function getPersonWithDetails(
 
   // Get dates ordered chronologically (date asc)
   const { data: dates, error: datesError } = await supabase
-    .from('dates')
+    .from('v_dates')
     .select('*')
     .eq('person_id', personId)
-    .is('deleted_at', null)
     .order('date', { ascending: true });
 
   if (datesError) {

--- a/api/people/person-schema.ts
+++ b/api/people/person-schema.ts
@@ -6,7 +6,6 @@ export const createPersonSchema = z.object({
     .trim()
     .min(1, 'Name is required')
     .max(60, 'Name must be 60 characters or less'),
-  photo_url: z.url().optional().nullable(),
 });
 
 export type CreatePersonForm = z.infer<typeof createPersonSchema>;

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -13,7 +13,7 @@ export default function HomeScreen() {
       </Text>
 
       <Text className="text-lg text-muted-foreground text-center mb-10">
-        Welcome back, {session?.user?.email}
+        Welcome back, {session?.user.user_metadata.name}
       </Text>
 
       <Button onPress={signOut}>

--- a/app/(tabs)/people.tsx
+++ b/app/(tabs)/people.tsx
@@ -29,8 +29,7 @@ function arePeopleListsEqual(a: Person[], b: Person[]): boolean {
   for (let i = 0; i < a.length; i++) {
     if (
       a[i].id !== b[i].id ||
-      a[i].name !== b[i].name ||
-      a[i].photo_url !== b[i].photo_url
+      a[i].name !== b[i].name
     ) {
       return false;
     }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -33,7 +33,7 @@ export default function Root() {
     <KeyboardProvider>
       <AuthProvider>
         <ThemeProvider value={isDarkColorScheme ? DARK_THEME : LIGHT_THEME}>
-          <StatusBar style={!isDarkColorScheme ? 'light' : 'dark'} />
+          <StatusBar style={!isDarkColorScheme ? 'dark' : 'light'} />
           <RootNavigator />
         </ThemeProvider>
       </AuthProvider>

--- a/app/add-person.tsx
+++ b/app/add-person.tsx
@@ -35,7 +35,6 @@ export default function AddPersonModal() {
     resolver: zodResolver(createPersonSchema),
     defaultValues: {
       name: '',
-      photo_url: null,
     },
     mode: 'onChange',
   });

--- a/postgres.txt
+++ b/postgres.txt
@@ -126,8 +126,16 @@ security definer
 set search_path = public
 as $$
 begin
-  insert into public.users (id) values (new.id)
-  on conflict (id) do nothing;
+  insert into public.users (id, display_name)
+  values (
+    new.id,
+    nullif(trim(new.raw_user_meta_data ->> 'name'), '')
+  )
+  on conflict (id) do update
+    set display_name = coalesce(
+      public.users.display_name,
+      excluded.display_name
+    );
   return new;
 end $$;
 

--- a/types/db.ts
+++ b/types/db.ts
@@ -7,7 +7,10 @@ export interface Tables {
     Row: {
       id: UUID;
       username: string | null;
-      avatar_url: string | null;
+      display_name: string | null;
+      timezone: string;
+      locale: string | null;
+      nudges_enabled: boolean;
       created_at: string; // ISO string
       updated_at: string;
       deleted_at: string | null;
@@ -15,11 +18,17 @@ export interface Tables {
     Insert: {
       id?: UUID;
       username?: string | null;
-      avatar_url?: string | null;
+      display_name?: string | null;
+      timezone?: string;
+      locale?: string | null;
+      nudges_enabled?: boolean;
     };
     Update: {
       username?: string | null;
-      avatar_url?: string | null;
+      display_name?: string | null;
+      timezone?: string;
+      locale?: string | null;
+      nudges_enabled?: boolean;
       deleted_at?: string | null;
     };
   };
@@ -29,7 +38,6 @@ export interface Tables {
       id: UUID;
       user_id: UUID;
       name: string;
-      photo_url: string | null;
       created_at: string;
       updated_at: string;
       deleted_at: string | null;
@@ -38,11 +46,9 @@ export interface Tables {
       id?: UUID;
       user_id: UUID;
       name: string;
-      photo_url?: string | null;
     };
     Update: {
       name?: string;
-      photo_url?: string | null;
       deleted_at?: string | null;
     };
   };
@@ -76,6 +82,9 @@ export interface Tables {
       person_id: UUID;
       label: string;
       date: string; // YYYY-MM-DD
+      month: number;
+      day: number;
+      year_known: boolean;
       created_at: string;
       updated_at: string;
       deleted_at: string | null;
@@ -118,7 +127,15 @@ export type PersonWithDetails = Person & {
 };
 
 export type TimelineEntry = Date & {
-  person: Pick<Person, 'id' | 'name' | 'photo_url'>;
+  person: Pick<Person, 'id' | 'name'>;
+};
+
+export type UpcomingDate = {
+  date_id: UUID;
+  person_id: UUID;
+  label: string;
+  event_date: string;
+  next_occurrence: string;
 };
 
 // Re-export service types for consistency

--- a/types/db.ts
+++ b/types/db.ts
@@ -8,7 +8,7 @@ export interface Tables {
       id: UUID;
       username: string | null;
       display_name: string | null;
-      timezone: string;
+      timezone: string | null;
       locale: string | null;
       nudges_enabled: boolean;
       created_at: string; // ISO string
@@ -19,14 +19,14 @@ export interface Tables {
       id?: UUID;
       username?: string | null;
       display_name?: string | null;
-      timezone?: string;
+      timezone?: string | null;
       locale?: string | null;
       nudges_enabled?: boolean;
     };
     Update: {
       username?: string | null;
       display_name?: string | null;
-      timezone?: string;
+      timezone?: string | null;
       locale?: string | null;
       nudges_enabled?: boolean;
       deleted_at?: string | null;


### PR DESCRIPTION
This PR includes:

- Added `.cursorrules`
- Aligned API reads with soft-delete schema: switched to `v_persons`/`v_facts`/`v_dates`, guarded child queries by parent existence, timeline now queries `v_dates` + `year_known`, and dropped manual `updated_at` stamping (DB triggers own it); user timezone type now matches nullable column
- Signup provisioning trigger now copies `raw_user_meta_data.name` into `public.users.display_name`, updating profiles on creation while preserving existing names